### PR TITLE
Fix transmission-trackers.py

### DIFF
--- a/transmission-trackers.py
+++ b/transmission-trackers.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 # Host, port, username and password to connect to Transmission
 # Set user and pw to None if auth is not required
 client = {
-  'host': 'localhost',
+  'address': 'localhost',
   'port': 9091,
   'user': 'admin',
   'password': 'passwd'


### PR DESCRIPTION
update the keyword parameter. The 'host' did not work for me. I changed to name to 'address' according to [`transmissionrpc`'s document](https://pythonhosted.org/transmissionrpc/reference/transmissionrpc.html#client-object)