### PR TITLE
Automatically Reannounce Torrent & Cronjob Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ Usage:
 * Adjust other parameters if needed (see comments)
 * Make the script run by cron e.g. every minute
 * You're done
+
+Cron Setup:
+* Open Crontab using crontab -e
+* For Updating Trackers to Every New Torrent Every 15 Minutes Add: */15 * * * * /usr/bin/sh [path]]/transmission-trackers-auto-cron.sh
+* Modify the transmission-trackers-auto.sh file as per your needs. We have provided two options, transmission-daemon & docker

--- a/transmission-trackers-auto-cron.sh
+++ b/transmission-trackers-auto-cron.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# If you are using transmission-daemon directly on system the below code will ensure that trackers script run only when it is running
+if [ "$(systemctl is-active transmission-daemon)" = "active" ]
+then
+/usr/bin/python3 [path]]/transmission-trackers.py
+fi
+
+# If you are using docker for transmission use the following. Replace 'docker-container-name' with the appropriate name
+if [ "$( docker container inspect -f '{{.State.Running}}' 'docker-container-name' )" = "true" ]
+then
+/usr/bin/python3 [path]]/transmission-trackers.py
+fi

--- a/transmission-trackers.py
+++ b/transmission-trackers.py
@@ -253,5 +253,7 @@ for t in torrents:
   if diff:
     lg('{}: Adding {} trackers (before: {})'.format(t.name, len(diff), len(ttrk)))
     tc.change_torrent(t.id, trackerAdd=list(diff))
+    time.sleep(1)
+    tc.reannounce_torrent(t.id)
   else:
     dbg('{}: update not needed'.format(t.name))


### PR DESCRIPTION
Hey,

I noticed that whenever new trackers are added the torrent is not announced immediately. It shows "Announce Not Scheduled" for around 20-30 minutes. Instead I used the inbuilt function of transmissionrpc library that allows the reannouncement. I have added a delay of 1 second once the trackers are added. It is working fine, I have been using it since about a week. It would be a good addition to this repo. 

Another commit is related to automating the trackers addition using cronjob. I have been using 2 instances of Transmissions, one directly on the raspberry pi and another one in a docker container. Both does not run 24x7 but when they are running this script will execute at decided interval (in my case 15 minutes) and add the trackers. I have also added the usage in the readme file. 

Thank You